### PR TITLE
Allow for the video img tag to be https or http

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+spaces_around_operators = true
+indent_brace_style = Allman
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,php}]
+charset = utf-8
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[{package.json,.travis.yml}]
+indent_size = 2
+
+[*.java]
+indent_brace_style = Stroustrup
+
+[*.go]
+indent_style = tab
+
+[*.{c++,cc,cxx}]
+indent_brace_style = Stroustrup

--- a/docker/dawg-db/Dockerfile
+++ b/docker/dawg-db/Dockerfile
@@ -1,3 +1,3 @@
-FROM mongo:3.2-rc
+FROM mongo:2.6
 MAINTAINER trent_schmidt@cable.comcast.com
 

--- a/libraries/dawg-client/src/main/java/com/comcast/video/dawg/cats/video/DawgVideoOutput.java
+++ b/libraries/dawg-client/src/main/java/com/comcast/video/dawg/cats/video/DawgVideoOutput.java
@@ -67,7 +67,12 @@ public class DawgVideoOutput implements VideoOutput {
      */
     protected String generateVideoUrl(String videoHost, String camera) {
         String cam = camera == null ? "1" : camera;
-        return (videoHost.startsWith("http://") ? "" : "http://") + videoHost + "/axis-cgi/mjpg/video.cgi?camera=" + cam + "&resolution=4CIF&fps=10";
+        if (    null != videoHost
+             && !(    videoHost.startsWith("http://")
+                   || videoHost.startsWith("https://"))) {
+            videoHost = "http://"+videoHost;
+        }
+        return videoHost + "/axis-cgi/mjpg/video.cgi?camera=" + cam + "&resolution=4CIF&fps=10";
     }
     /**
      * {@inheritDoc}

--- a/libraries/dawg-client/src/main/java/com/comcast/video/dawg/cats/video/DawgVideoOutput.java
+++ b/libraries/dawg-client/src/main/java/com/comcast/video/dawg/cats/video/DawgVideoOutput.java
@@ -69,7 +69,8 @@ public class DawgVideoOutput implements VideoOutput {
         String cam = camera == null ? "1" : camera;
         if (    null != videoHost
              && !(    videoHost.startsWith("http://")
-                   || videoHost.startsWith("https://"))) {
+                   || videoHost.startsWith("https://")))
+        {
             videoHost = "http://"+videoHost;
         }
         return videoHost + "/axis-cgi/mjpg/video.cgi?camera=" + cam + "&resolution=4CIF&fps=10";

--- a/libraries/dawg-show/src/main/java/com/comcast/video/dawg/show/ViewController.java
+++ b/libraries/dawg-show/src/main/java/com/comcast/video/dawg/show/ViewController.java
@@ -105,6 +105,13 @@ public class ViewController implements ViewConstants {
             boolean supported = BrowserSupport.isBrowserSupported(uaStr);
             String videoUrl = stb.getVideoSourceUrl();
 
+            if (    null != videoUrl
+                 && !(    videoUrl.startsWith("http://")
+                       || videoUrl.startsWith("https://")))
+           {
+               videoUrl = "http://" + videoUrl;
+           }
+
             Boolean mob = false;
 
             if (mobile == null) {

--- a/libraries/dawg-show/src/main/webapp/views/multi.jsp
+++ b/libraries/dawg-show/src/main/webapp/views/multi.jsp
@@ -115,7 +115,7 @@ String genericRemoteKeys = (String)request.getAttribute(ViewConstants.GENERIC_RE
                         <div class="videoBody">
                             <c:choose>
                             <c:when test="${empty stb.hdVideoUrl}">
-                            <img id="video" class="video" src="http://${stb.videoSourceUrl}/axis-cgi/mjpg/video.cgi?camera=${stb.videoCamera}" alt=""></img>
+                            <img id="video" class="video" src="${stb.videoSourceUrl}/axis-cgi/mjpg/video.cgi?camera=${stb.videoCamera}" alt=""></img>
                             </c:when>
                             <c:otherwise>
                             <canvas id="video" class="video" data-videourl="${stb.hdVideoUrl}"></canvas>

--- a/libraries/dawg-show/src/main/webapp/views/stb.jsp
+++ b/libraries/dawg-show/src/main/webapp/views/stb.jsp
@@ -47,7 +47,7 @@ String deviceId = (String) request.getAttribute(ViewConstants.DEVICE_ID);
 boolean supported = (Boolean) request.getAttribute(ViewConstants.SUPPORTED);
 String stdRemotePage = "/views/remotes/" + remote.getImageSubpath() + "/standard/standardremote.jsp";
 String miniRemotePage = "/views/remotes/" + remote.getImageSubpath() + "/mini/miniremote.jsp";
-String fullVideoUrl = "http://" + videoUrl + "/axis-cgi/mjpg/video.cgi"
+String fullVideoUrl = videoUrl + "/axis-cgi/mjpg/video.cgi"
 + (videoCamera != null ? "?camera=" + videoCamera : "");
 String fullAudioUrlMP3Extension = "http://" + audioUrl + ":" + audioPort + "/play1.mp3";
 String fullAudioUrlOGGExtension = "http://" + audioUrl + ":" + audioPort + "/play1.ogg";


### PR DESCRIPTION
This allows for the db to have http:// or https:// for the video source and it not prepend that portion.  It will also still allow for no http:// to be present and auto add it to the video url.
